### PR TITLE
Api, importer and transformer to different accounts 

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -36,10 +36,10 @@ export const TZ = readEnvironmentVariable('TZ', {defaultValue: ''});
 export const API_URL = readEnvironmentVariable('API_URL');
 export const API_USERNAME = readEnvironmentVariable('API_USERNAME');
 export const API_PASSWORD = readEnvironmentVariable('API_PASSWORD');
-export const IMPORTER_USERNAME = readEnvironmentVariable('IMPORTER_USERNAME');
-export const IMPORTER_PASSWORD = readEnvironmentVariable('IMPORTER_PASSWORD');
-export const TRANSFORMER_USERNAME = readEnvironmentVariable('TRANSFORMER_USERNAME');
-export const TRANSFORMER_PASSWORD = readEnvironmentVariable('TRANSFORMER_PASSWORD');
+export const API_USERNAME_IMPORTER = readEnvironmentVariable('API_USERNAME_IMPORTER');
+export const API_PASSWORD_IMPORTER = readEnvironmentVariable('API_PASSWORD_IMPORTER');
+export const API_USERNAME_TRANSFORMER = readEnvironmentVariable('API_USERNAME_TRANSFORMER');
+export const API_PASSWORD_TRANSFORMER = readEnvironmentVariable('API_PASSWORD_TRANSFORMER');
 
 export const MONGO_URI = readEnvironmentVariable('MONGO_URI', {defaultValue: 'mongodb://127.0.0.1/db'});
 export const AMQP_URL = readEnvironmentVariable('AMQP_URL', {defaultValue: 'amqp://127.0.0.1:5672'});
@@ -99,8 +99,8 @@ export const CONTAINER_TEMPLATE_TRANSFORMER = {
 	Env: [
 		`AMQP_URL=${AMQP_URL}`,
 		`API_URL=${API_URL}`,
-		`API_USERNAME=${TRANSFORMER_USERNAME}`,
-		`API_PASSWORD=${TRANSFORMER_PASSWORD}`,
+		`API_USERNAME=${API_USERNAME_TRANSFORMER}`,
+		`API_PASSWORD=${API_PASSWORD_TRANSFORMER}`,
 		'ABORT_ON_INVALID_RECORDS=false',
 		`DEBUG=${process.env.DEBUG}`
 	],
@@ -121,8 +121,8 @@ export const CONTAINER_TEMPLATE_IMPORTER = {
 	Env: [
 		`AMQP_URL=${AMQP_URL}`,
 		`API_URL=${API_URL}`,
-		`API_USERNAME=${IMPORTER_USERNAME}`,
-		`API_PASSWORD=${IMPORTER_PASSWORD}`,
+		`API_USERNAME=${API_USERNAME_IMPORTER}`,
+		`API_PASSWORD=${API_PASSWORD_IMPORTER}`,
 		`DEBUG=${process.env.DEBUG}`
 	],
 	Healthcheck: {

--- a/src/config.js
+++ b/src/config.js
@@ -36,6 +36,10 @@ export const TZ = readEnvironmentVariable('TZ', {defaultValue: ''});
 export const API_URL = readEnvironmentVariable('API_URL');
 export const API_USERNAME = readEnvironmentVariable('API_USERNAME');
 export const API_PASSWORD = readEnvironmentVariable('API_PASSWORD');
+export const IMPORTER_USERNAME = readEnvironmentVariable('IMPORTER_USERNAME');
+export const IMPORTER_PASSWORD = readEnvironmentVariable('IMPORTER_PASSWORD');
+export const TRANSFORMER_USERNAME = readEnvironmentVariable('TRANSFORMER_USERNAME');
+export const TRANSFORMER_PASSWORD = readEnvironmentVariable('TRANSFORMER_PASSWORD');
 
 export const MONGO_URI = readEnvironmentVariable('MONGO_URI', {defaultValue: 'mongodb://127.0.0.1/db'});
 export const AMQP_URL = readEnvironmentVariable('AMQP_URL', {defaultValue: 'amqp://127.0.0.1:5672'});
@@ -95,8 +99,8 @@ export const CONTAINER_TEMPLATE_TRANSFORMER = {
 	Env: [
 		`AMQP_URL=${AMQP_URL}`,
 		`API_URL=${API_URL}`,
-		`API_USERNAME=${API_USERNAME}`,
-		`API_PASSWORD=${API_PASSWORD}`,
+		`API_USERNAME=${TRANSFORMER_USERNAME}`,
+		`API_PASSWORD=${TRANSFORMER_PASSWORD}`,
 		'ABORT_ON_INVALID_RECORDS=false',
 		`DEBUG=${process.env.DEBUG}`
 	],
@@ -117,8 +121,8 @@ export const CONTAINER_TEMPLATE_IMPORTER = {
 	Env: [
 		`AMQP_URL=${AMQP_URL}`,
 		`API_URL=${API_URL}`,
-		`API_USERNAME=${API_USERNAME}`,
-		`API_PASSWORD=${API_PASSWORD}`,
+		`API_USERNAME=${IMPORTER_USERNAME}`,
+		`API_PASSWORD=${IMPORTER_PASSWORD}`,
 		`DEBUG=${process.env.DEBUG}`
 	],
 	Healthcheck: {


### PR DESCRIPTION
### .yml file
Needs 2 new account to be added for importer and transformer
changes:
```
controller:
    image: melinda-record-import-controller
    depends_on:
    - api
    - db
    - mq
    volumes:
    - /etc/localtime:/etc/localtime:ro
    - /var/run/docker.sock:/var/run/docker.sock
    environment:            
      API_URL: ${API_URL}
      API_USERNAME: foo
      API_PASSWORD: bar
      API_USERNAME_IMPORTER: faa
      API_PASSWORD_IMPORTER: fuu
      API_USERNAME_TRANSFORMER: fii
      API_PASSWORD_TRANSFORMER: faa
      AMQP_URL: amqp://mq
      MONGO_URI: mongodb://db/db
      BLOB_METADATA_TTL: '1 hour'
      BLOB_CONTENT_TTL: '15 minutes'
      CONTAINER_NETWORKS: "[\"record-import_mq\"]"
      JOB_FREQ_PRUNE_CONTAINERS: 'never'
      DEBUG: 1
    deploy:
      restart_policy:
        condition: any
```

### users.json
Needs 2 new profiles for importer and transformer.
IMPORTANT: Make transformer and importer to have same organization group, example: `"foo"`.
 - Also "creator" (harvester) needs this group to match. 
changes:
```
    {
        "id": "foo",
        "password": "bar",
        "name": {
            "givenName": "foo",
            "familyName": "bar"
        },
        "displayName": "foo",
        "emails": [{"value": "foo@fu.bar", "type": "work"}],
        "organization": [],
        "groups": [
            "system"
        ]
    },
    {
        "id": "faa",
        "password": "fuu",
        "name": {
            "givenName": "faa",
            "familyName": "bar"
        },
        "displayName": "faa",
        "emails": [{"value": "foo@fu.bar", "type": "work"}],
        "organization": [],
        "groups": [
            "importer",
	    "foo"
        ]
    },
    {
        "id": "fii",
        "password": "faa",
        "name": {
            "givenName": "fii",
            "familyName": "bar"
        },
        "displayName": "fii",
        "emails": [{"value": "foo@fu.bar", "type": "work"}],
        "organization": [],
        "groups": [
            "transformer"
	    "foo"
        ]
    }
```

### NOTE:
- In case of `melinda-record-import-cli` usage profile files auth groups needs to be updated: `'admin'` -> `'system'`
- This version of implementation does not need changes to `importer` or `transformer`, they still use internally `API_USERNAME` and `API_PASSWORD`