### PR TITLE
fix importer concurrency

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ import {
 	JOB_BLOBS_PENDING, JOB_BLOBS_TRANSFORMED, JOB_BLOBS_ABORTED,
 	JOB_BLOBS_METADATA_CLEANUP, JOB_BLOBS_CONTENT_CLEANUP, JOB_BLOBS_MISSING_RECORDS,
 	JOB_CONTAINERS_HEALTH, JOB_PRUNE_CONTAINERS, JOB_UPDATE_IMAGES,
-	JOB_FREQ_BLOBS_PENDING, JOB_FREQ_BLOBS_TRANSFORMED,	JOB_FREQ_BLOBS_ABORTED,
+	JOB_FREQ_BLOBS_PENDING, JOB_FREQ_BLOBS_TRANSFORMED, JOB_FREQ_BLOBS_ABORTED,
 	JOB_FREQ_CONTAINERS_HEALTH, JOB_FREQ_PRUNE_CONTAINERS, JOB_FREQ_UPDATE_IMAGES,
 	JOB_FREQ_BLOBS_METADATA_CLEANUP, JOB_FREQ_BLOBS_CONTENT_CLEANUP,
 	JOB_FREQ_BLOBS_MISSING_RECORDS, JOB_BLOBS_TRANSFORMATION_QUEUE_CLEANUP,
@@ -49,7 +49,7 @@ run();
 
 async function run() {
 	const Logger = createLogger();
-	const Mongo = await MongoClient.connect(MONGO_URI, {useNewUrlParser: true});
+	const Mongo = await MongoClient.connect(MONGO_URI, {useNewUrlParser: true, useUnifiedTopology: true});
 
 	if (await isSupportedDockerVersion() === false) {
 		Logger.log('error', 'Docker API version is not supported');
@@ -67,7 +67,7 @@ async function run() {
 		.on('uncaughtException', handleExit);
 
 	await initDb();
-	const agenda = new Agenda({mongo: Mongo.db()});
+	const agenda = new Agenda({mongo: Mongo.db(), defaultConcurrency: 1});
 
 	// Agenda.sort({nextRunAt: 1});
 

--- a/src/jobs/dispatch.js
+++ b/src/jobs/dispatch.js
@@ -159,14 +159,14 @@ export default function (agenda) {
 					}
 
 					const profile = await getProfile(profileId, profileCache);
-					const {dispatchCount, totalLimitAfterDispatch} = await getDispatchCount(profile);
+					const {dispatch, totalLimitAfterDispatch} = await getDispatchCount(profile);
 
-					if (dispatchCount > 0) {
+					if (dispatch) {
 						if (isOfflinePeriod()) {
 							logger.log('debug', 'Not dispatching importers during offline period');
 						} else {
 							logger.log('debug', `Dispatching 1 import containers for blob ${id}`);
-							await dispatchImporters({id, docker, dispatchCount, profile});
+							await dispatchImporter({id, docker, profile});
 							blobsTryCount[id] = blobsTryCount[id] ? blobsTryCount[id] + 1 : 1;
 
 							if (totalLimitAfterDispatch < 1) {
@@ -230,13 +230,13 @@ export default function (agenda) {
 					if (availImporters > 0 && availTotal > 0) {
 						if (availTotal > availImporters) {
 							return {
-								dispatchCount: 1,
+								dispatch: true,
 								totalLimitAfterDispatch: availImporters - 1
 							};
 						}
 
 						return {
-							dispatchCount: 1,
+							dispatchCount: true,
 							totalLimitAfterDispatch: availTotal - 1
 						};
 					}
@@ -244,7 +244,7 @@ export default function (agenda) {
 					return {dispatchCount: 0};
 				}
 
-				async function dispatchImporters({id, docker, dispatchCount, profile}) {
+				async function dispatchImporter({id, docker, profile}) {
 					return Promise.all(map(async () => {
 						try {
 							await dispatchContainer({
@@ -261,7 +261,7 @@ export default function (agenda) {
 					}));
 
 					function map(cb) {
-						return new Array(dispatchCount).fill(0).map(cb);
+						return new Array(1).fill(0).map(cb);
 					}
 				}
 			}

--- a/src/jobs/utils.js
+++ b/src/jobs/utils.js
@@ -72,7 +72,7 @@ export async function processBlobs({client, query, processCallback, messageCallb
 				const filteredBlobs = blobs.filter(filter);
 
 				blobsTotal += filteredBlobs.length;
-				pendingProcessors.push(processCallback(filteredBlobs));
+				pendingProcessors.push(processCallback(filteredBlobs, pendingProcessors.length !== 0));
 			})
 			.on('end', () => {
 				if (messageCallback) {


### PR DESCRIPTION
Utils / processBlobs gets 5 blobs at the time from client and it is so fast that 3-8 processCallbacks were running same time causing importer concurrency to go haywire.

Also controller can dispatch multiple importers to one blob and it can cause a problems